### PR TITLE
Use Big Decimal to determine integer precisely, fix #23224

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -1,3 +1,5 @@
+require 'bigdecimal'
+
 module ActiveModel
 
   module Validations
@@ -77,7 +79,7 @@ module ActiveModel
       end
 
       def is_integer?(raw_value)
-        /\A[+-]?\d+\z/ === raw_value.to_s
+        BigDecimal.new(raw_value.to_s).frac == 0
       end
 
       def filtered_options(value)

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -17,6 +17,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
   BIGDECIMAL_STRINGS = %w(12345678901234567890.1234567890) # 30 significant digits
   FLOAT_STRINGS = %w(0.0 +0.0 -0.0 10.0 10.5 -10.5 -0.0001 -090.1 90.1e1 -90.1e5 -90.1e-5 90e-5)
   INTEGER_STRINGS = %w(0 +0 -0 10 +10 -10 0090 -090)
+  INTEGER_AS_DECIMALS = %w(0.0, +0.0, -0.0, 1.0, -2.0, 3.00, -4.000000000000)
   FLOATS = [0.0, 10.0, 10.5, -10.5, -0.0001] + FLOAT_STRINGS
   INTEGERS = [0, 10, -10] + INTEGER_STRINGS
   BIGDECIMAL = BIGDECIMAL_STRINGS.collect! { |bd| BigDecimal.new(bd) }
@@ -41,6 +42,14 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
     invalid!(NIL + BLANK + JUNK + FLOATS + BIGDECIMAL + INFINITY)
     valid!(INTEGERS)
+  end
+  
+  def test_validates_numericality_of_with_integer_only_for_integer_in_decimal_format
+    Topic.validates_numericality_of :approved, only_integer: true
+
+    invalid!(NIL + BLANK + JUNK + FLOATS + BIGDECIMAL + INFINITY)
+    valid!(INTEGERS)
+    valid!(INTEGER_AS_DECIMALS)
   end
 
   def test_validates_numericality_of_with_integer_only_and_nil_allowed


### PR DESCRIPTION
As discussed in #23224, simply checking number format is not reliable, importing Big Decimal fixes it, while does not bring much impact in performance.
Comparision and benchmark: 
https://gist.github.com/southwolf/b6ae3c8ff82e959548ac